### PR TITLE
fix: Fix menu by changing window.onclick event listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
         <!-- Menu icon -->
         <div class="menu-icon" onclick="toggleMenu()">
-            <img src="3_lines.png" alt="GitHub Menu">
+            <img id="menuBurgerIcon" src="3_lines.png" alt="GitHub Menu">
             <!-- Menu content -->
             <div class="menu-content" id="menuContent">
                 <!-- Placeholder content -->

--- a/script.js
+++ b/script.js
@@ -6,9 +6,9 @@ function toggleMenu() {
 
 // Function to hide the menu content when clicking outside of it
 window.onclick = function(event) {
-    var menuIcon = document.querySelector('.menu-icon');
+    var menuBurgerIcon = document.querySelector('#menuBurgerIcon');
     var menuContent = document.getElementById("menuContent");
-    if (!event.target.matches('.menu-icon') && !event.target.matches('.menu-content') && !menuContent.contains(event.target)) {
+    if (!event.target.contains(menuBurgerIcon) && !menuContent.contains(event.target)) {
         menuContent.classList.remove('show'); // Remove the "show" class
     }
 }


### PR DESCRIPTION
[Menu was hidden right after it was show because of `window.onclick` wrong behaviour](https://stackoverflow.com/questions/78427553/broken-button-that-doesnt-work-when-i-click-on-it)

`toggleMenu` function was working properly, but the menu was being hidden immediatly after because of the wrong if condition.

I've fixed it by giving an id to the menu burger image (event target) and verifying if the event target contains it ([works if its also the element itself](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)).